### PR TITLE
feat: add support for non json request content type

### DIFF
--- a/ask-sdk-model-runtime/lib/index.ts
+++ b/ask-sdk-model-runtime/lib/index.ts
@@ -316,7 +316,9 @@ export abstract class BaseServiceClient {
             headers : headerParams,
         };
         if (bodyParam != null) {
-            request.body = nonJsonBody ? bodyParam : JSON.stringify(bodyParam);
+            const contentType = headerParams.find((header) => header.key.toLowerCase() === 'content-type');
+            const contentTypeNonJson = contentType && !contentType.value.includes('application/json');
+            request.body = nonJsonBody || contentTypeNonJson ? bodyParam : JSON.stringify(bodyParam);
         }
 
         const apiClient = this.apiConfiguration.apiClient;

--- a/ask-sdk-model-runtime/tst/index.spec.ts
+++ b/ask-sdk-model-runtime/tst/index.spec.ts
@@ -124,6 +124,35 @@ describe('BaseServiceClient', () => {
                                 });
     });
 
+    it('should not serialize the request body when content type header is not application/json', async() => {
+        const apiClient = new MockApiClient();
+        apiClient.response = {
+            statusCode : 200,
+            headers : [],
+            body: null,
+        };
+        const client = new MockServiceClient(apiClient);
+
+        const result = await client.invokePublic(
+            '',
+            '',
+            '',
+            emptyParamsMap,
+            emptyQueryParams,
+            [{key: 'Content-type', value: 'text/csv'}],
+            'nonJson body',
+            emptyErrorsMap,
+        );
+
+        expect(apiClient.request.url).eq('');
+        expect(apiClient.request.method).eq('');
+        expect(apiClient.request.body).eq('nonJson body');
+        expect(result).deep.eq({headers: [],
+                                statusCode: 200,
+                                body: undefined,
+                                });
+    });
+
     it('should build url', async() => {
         const apiClient = new MockApiClient();
         apiClient.response = {


### PR DESCRIPTION
Some smapi api support text/csv content type.

Adding support for non json content type.

It cannot be accomplished with nonJsonBody params since functions in ask smapi model need to support both json and csv, so it needs to be dynamic during runtime.
