### PR TITLE
Add boolean type to the value of SetValueCommand

### DIFF
--- a/ask-sdk-model/index.ts
+++ b/ask-sdk-model/index.ts
@@ -6232,7 +6232,7 @@ export namespace interfaces.alexa.presentation.apl {
         /**
          * The property value to set.
          */
-        'value': string;
+        'value': string | boolean;
     }
 }
 
@@ -6919,7 +6919,7 @@ export namespace interfaces.alexa.presentation.aplt {
         /**
          * The property value to set.
          */
-        'value': string;
+        'value': string | boolean;
     }
 }
 


### PR DESCRIPTION
## What

Add boolean type to `value` property of SetValue.

## Why

SetValue should set not only string type value but also boolean, number type value.  For example, when I want to set the `TouchWrapper` 's `disbaled` to true, I can't. Because "false" string is evaluated as true in APL runtime.

https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-data-binding-syntax.html#truthy-and-coercion 

Following document, TouchWrapper would be disabled even though I set disabled status to "false".
```json
     {
        "type": "Container",
        "width": "100vw",
        "height": "100vh",
        "items": [
          {
            "type": "TouchWrapper",
            "bind": [
              {
                "name": "myText",
                "value": "Hello world"
              }
            ],
            "onMount": [
              {
                "type": "SetValue",
                "property": "disabled",
                "value": "false" <- Would be disabled because "false" is evaluated as true!!!!
              }
            ],
            "onPress": [
              {
                "type": "SetValue",
                "property": "myText",
                "value": "Hello world again"
              }
            ],
            "items": [
              {
                "type": "Text",
                "text": " ${myText}"
              }
            ]
          }
        ]
      }
```

So I want to deal boolean value in SetValue command.

## How

Add `boolean` type to the `value` property of SetValueCommand