### PR TITLE
Add types for `Advertising` object

### DIFF
--- a/ask-sdk-model/index.ts
+++ b/ask-sdk-model/index.ts
@@ -513,6 +513,11 @@ export interface Context {
      * Provides the current experimentation state
      */
     'Experimentation'?: interfaces.alexa.experimentation.ExperimentationState;
+    /**
+     * Provides the customer's advertising ID and preference for receiving interest-based ads
+     */
+    'Advertising'?: interfaces.alexa.advertising.Advertising;
+
 }
 
 /**
@@ -1133,6 +1138,26 @@ export namespace events.skillevents {
         'eventName'?: string;
     }
 }
+
+export namespace interfaces.alexa.advertising {
+    /**
+     * A map that provides the customer's advertising ID and preference for receiving interest-based ads.
+     * @interface
+     */
+    export interface Advertising {
+        /**
+         * The customer's advertising ID.
+         * Customer-resettable, unique identifier that maps to the ifa attribute of the OpenRTB API specification.
+         * Formatted as a version 4 UUID string separated by dashes (8-4-4-4-12).
+         */
+        'advertisingId': string;
+        /**
+         * Indicates whether the customer wants to receive interest-based ads. Set to true when the customer opts out of interest-based ads and tracking.
+         * Maps to the lmt attribute of the OpenRTB API specification.
+         */
+        'limitAdTracking': boolean;
+    }
+  }
 
 export namespace interfaces.alexa.comms.messagingcontroller {
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds type definition for `request.context.Advertising` object, as per [Alexa docs](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#advertising-object).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
